### PR TITLE
fix: added additional configuration to allow jest-runner to run from vscode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,22 @@
 module.exports = {
-    maxWorkers: 1,
-    collectCoverage: true,
-    coverageReporters: ['html', 'json-summary'],
-    globals: {
-        'ts-jest': {
-        allowSyntheticDefaultImports: true,
-        },
-    },
-    transform: {
-        '^.+\\.js$': 'babel-jest',
-    },
+	// source: https://github.com/thymikee/jest-preset-angular#configuration
+	// 'jest-preset-angular' is normally configured through '@angular-builders/jest' cli builder
+	// but to allow for using jest-runner, it needs to be setup in base jest.config.js
+	preset: 'jest-preset-angular',
+	setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
+	globalSetup: 'jest-preset-angular/global-setup',
+	testEnvironment: 'jsdom',
+	maxWorkers: 1,
+	collectCoverage: true,
+	coverageReporters: ['html', 'json-summary'],
+	globals: {
+		'ts-jest': {
+			tsconfig: 'tsconfig.spec.json',
+			// required to allow for babel-jest on js files
+			allowSyntheticDefaultImports: true,
+		},
+	},
+	transform: {
+		'^.+\\.js$': 'babel-jest',
+	},
 };

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,2 @@
+// source: https://github.com/thymikee/jest-preset-angular#configuration
+import 'jest-preset-angular/setup-jest';

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -41,6 +41,11 @@ class MockMatDateRangePickerComponent {}
 })
 class MockMatDatepickerToggleComponent {}
 
+@Component({
+	selector: 'app-package-list',
+})
+class MockPackageListComponent {}
+
 describe('AppComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
@@ -56,6 +61,7 @@ describe('AppComponent', () => {
 				MockMatDateRangeInputComponent,
 				MockMatDateRangePickerComponent,
 				MockMatDatepickerToggleComponent,
+				MockPackageListComponent,
 			],
 			providers: [
 				{

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -2,4 +2,3 @@ export * from './npm-registry';
 export * from './storage';
 export * from './date';
 export * from './error-handler';
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 if (environment.production) {
-  enableProdMode();
+	enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+platformBrowserDynamic()
+	.bootstrapModule(AppModule)
+	.catch((err) => console.error(err));

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -45,8 +45,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js';  // Included with Angular CLI.
-
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,18 +1,11 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
-  },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"outDir": "./out-tsc/spec",
+		"types": ["jest"]
+	},
+	"files": ["src/polyfills.ts"],
+	"include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
### Description
Currently jest-runner plugin for vscode doesn't work. Missing configuration to use `jest-preset-angular` from base jest config file found at `jest.config.js`

### Observation
When running to use `jest-runner` vscode plugin, inline run command doesn't work (allows you to run jest tests for specific spec file)

### Steps to Recreate
Open `src/app/components/package-list/package-list.component.spec.ts`, there is a prompt above 

```typescript
describe('PackageListComponent', () => {
```

introduced by `jest-runner` plugin on vscode (one of the recommended plugins for this project)

When attempting to run, console is filled with errors. Other way to recreate is to run `npx jest`

### Code changes

1. Missing lint from other files such as `main.ts`
2. Added missing mock in `AppComponent` spec file
3. Updated `jest.config.js` to include `jest-preset-angular` configuration
4. Added `setup-jest.ts` to initialize `jest-preset-angular` for `npx jest` and `jest-runner` plugin

### Screenshot
![Screen Shot 2022-09-27 at 4 17 36 PM](https://user-images.githubusercontent.com/9206193/192654647-12fb73fb-8459-4750-a5d6-1254efcf5f73.png)
