### PR TITLE
Feature/aos2 14 date range picker migration

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,28 +1,6 @@
 <div class="flex-row margin-row">
 	<form onsubmit="return false">
-		<mat-form-field appearance="fill">
-			<mat-label>Enter a date range</mat-label>
-			<mat-date-range-input
-				[formGroup]="dateRangeFormGroup"
-				[rangePicker]="picker"
-				[min]="minDate"
-				[max]="maxDate"
-				required
-			>
-				<input matStartDate formControlName="start" placeholder="Start date" />
-				<input matEndDate formControlName="end" placeholder="End date" />
-			</mat-date-range-input>
-
-			<mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
-			<mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-			<mat-date-range-picker #picker></mat-date-range-picker>
-			<mat-error
-				appErrorHandler
-				[errors$]="[dateRangeFormGroup.controls.start.errors | toObservable, dateRangeFormGroup.controls.end.errors | toObservable]"
-				[handleErrors]="[startDateErrorsHandler, endDateErrorsHandler]"
-			>
-			</mat-error>
-		</mat-form-field>
+		<app-date-range-picker [formControl]="dateRangeFormControl"></app-date-range-picker>
 	</form>
 
 	<div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -29,11 +29,6 @@ form {
 	}
 }
 
-mat-form-field {
-	max-width: 320px;
-	width: 100%;
-}
-
 .clear-cache-button:not(:focus):not(:hover) {
 	transition: color 200ms cubic-bezier(0.35, 0, 0.25, 1);
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -27,24 +27,14 @@ class MockMatErrorComponent {}
 class MockMatFormFieldComponent {}
 
 @Component({
-	selector: 'mat-date-range-input',
-})
-class MockMatDateRangeInputComponent {}
-
-@Component({
-	selector: 'mat-date-range-picker',
-})
-class MockMatDateRangePickerComponent {}
-
-@Component({
-	selector: 'mat-datepicker-toggle',
-})
-class MockMatDatepickerToggleComponent {}
-
-@Component({
 	selector: 'app-package-list',
 })
 class MockPackageListComponent {}
+
+@Component({
+	selector: 'app-date-range-picker',
+})
+class MockDateRangePickerComponent {}
 
 describe('AppComponent', () => {
 	beforeEach(async () => {
@@ -58,10 +48,8 @@ describe('AppComponent', () => {
 				MockMatHintComponent,
 				MockMatErrorComponent,
 				MockMatFormFieldComponent,
-				MockMatDateRangeInputComponent,
-				MockMatDateRangePickerComponent,
-				MockMatDatepickerToggleComponent,
 				MockPackageListComponent,
+				MockDateRangePickerComponent,
 			],
 			providers: [
 				{

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,10 +25,9 @@ import {
 import { formatNumber } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ArrayObservable } from './classes';
-import { ChartData } from './models';
+import { ChartData, DateRange } from './models';
 import { DateService, ErrorHandlerService, NpmRegistryService, StorageService } from './services';
 import { RegistryData } from './services/npm-registry/npm-registry.model';
-import { DateRange } from './components/date-range-picker/date-range-picker.component';
 
 type RegistryError = { error?: { error?: string }; message?: string };
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,9 +19,17 @@ import { FooterComponent } from './components/footer/footer.component';
 import { PackageListComponent } from './components/package-list/package-list.component';
 import { ErrorHandlerDirective } from './directives';
 import { ToObservablePipe } from './pipes';
+import { DateRangePickerComponent } from './components/date-range-picker/date-range-picker.component';
 
 @NgModule({
-	declarations: [AppComponent, ToObservablePipe, ErrorHandlerDirective, FooterComponent, PackageListComponent],
+	declarations: [
+		AppComponent,
+		ToObservablePipe,
+		ErrorHandlerDirective,
+		FooterComponent,
+		PackageListComponent,
+		DateRangePickerComponent,
+	],
 	imports: [
 		BrowserModule,
 		BrowserAnimationsModule,

--- a/src/app/components/chart/chart.component.spec.ts
+++ b/src/app/components/chart/chart.component.spec.ts
@@ -1,6 +1,19 @@
+import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { GoogleChartComponent } from 'angular-google-charts';
 
 import { ChartComponent } from './chart.component';
+
+@Component({
+	selector: 'google-chart',
+})
+class MockGoogleChartComponent {
+	@Input() type!: GoogleChartComponent['type'];
+	@Input() data!: GoogleChartComponent['data'];
+	@Input() options!: GoogleChartComponent['options'];
+	@Input() columns!: GoogleChartComponent['columns'];
+	@Input() dynamicResize!: GoogleChartComponent['dynamicResize'];
+}
 
 describe('ChartComponentComponent', () => {
 	let component: ChartComponent;
@@ -8,11 +21,16 @@ describe('ChartComponentComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [ChartComponent],
+			declarations: [ChartComponent, MockGoogleChartComponent],
 		}).compileComponents();
 
 		fixture = TestBed.createComponent(ChartComponent);
 		component = fixture.componentInstance;
+		component.chartData = {
+			rows: [],
+			columns: [],
+			options: [],
+		};
 		fixture.detectChanges();
 	});
 

--- a/src/app/components/date-range-picker/date-range-picker.component.html
+++ b/src/app/components/date-range-picker/date-range-picker.component.html
@@ -1,0 +1,22 @@
+<mat-form-field appearance="fill">
+	<mat-label>Enter a date range</mat-label>
+	<mat-date-range-input
+		[formGroup]="dateRangeFormGroup"
+		[rangePicker]="picker"
+		[min]="minDate"
+		[max]="maxDate"
+		required
+	>
+		<input matStartDate formControlName="start" placeholder="Start date" />
+		<input matEndDate formControlName="end" placeholder="End date" />
+	</mat-date-range-input>
+	<mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
+	<mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+	<mat-date-range-picker #picker></mat-date-range-picker>
+	<mat-error
+		appErrorHandler
+		[errors$]="[dateRangeFormGroup.controls.start.errors | toObservable, dateRangeFormGroup.controls.end.errors | toObservable]"
+		[handleErrors]="[startDateErrorsHandler, endDateErrorsHandler]"
+	>
+	</mat-error>
+</mat-form-field>

--- a/src/app/components/date-range-picker/date-range-picker.component.scss
+++ b/src/app/components/date-range-picker/date-range-picker.component.scss
@@ -1,0 +1,3 @@
+:host {
+	display: block;
+}

--- a/src/app/components/date-range-picker/date-range-picker.component.spec.ts
+++ b/src/app/components/date-range-picker/date-range-picker.component.spec.ts
@@ -1,6 +1,52 @@
+import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDateRangeInput } from '@angular/material/datepicker';
+import { ErrorHandlerDirective } from '../../directives';
+import { ToObservablePipe } from '../../pipes';
 
 import { DateRangePickerComponent } from './date-range-picker.component';
+
+@Component({
+	selector: 'mat-label',
+})
+class MockMatLabelComponent {}
+
+@Component({
+	selector: 'mat-hint',
+})
+class MockMatHintComponent {}
+
+@Component({
+	selector: 'mat-error',
+})
+class MockMatErrorComponent {}
+
+@Component({
+	selector: 'mat-form-field',
+})
+class MockMatFormFieldComponent {}
+
+@Component({
+	selector: 'mat-date-range-input',
+})
+class MockMatDateRangeInputComponent {
+	@Input() min!: Date;
+	@Input() max!: Date;
+	@Input() rangePicker!: MatDateRangeInput<Date>['rangePicker'];
+}
+
+@Component({
+	selector: 'mat-date-range-picker',
+})
+class MockMatDateRangePickerComponent {}
+
+@Component({
+	selector: 'mat-datepicker-toggle',
+})
+class MockMatDatepickerToggleComponent {
+	@Input() for!: MatDateRangeInput<Date>;
+}
 
 describe('DateRangePickerComponent', () => {
 	let component: DateRangePickerComponent;
@@ -8,7 +54,19 @@ describe('DateRangePickerComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [DateRangePickerComponent],
+			declarations: [
+				DateRangePickerComponent,
+				MockMatLabelComponent,
+				MockMatHintComponent,
+				MockMatErrorComponent,
+				MockMatFormFieldComponent,
+				MockMatDateRangeInputComponent,
+				MockMatDateRangePickerComponent,
+				MockMatDatepickerToggleComponent,
+				ToObservablePipe,
+				ErrorHandlerDirective,
+			],
+			imports: [ReactiveFormsModule],
 		}).compileComponents();
 
 		fixture = TestBed.createComponent(DateRangePickerComponent);

--- a/src/app/components/date-range-picker/date-range-picker.component.spec.ts
+++ b/src/app/components/date-range-picker/date-range-picker.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DateRangePickerComponent } from './date-range-picker.component';
+
+describe('DateRangePickerComponent', () => {
+	let component: DateRangePickerComponent;
+	let fixture: ComponentFixture<DateRangePickerComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [DateRangePickerComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(DateRangePickerComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/date-range-picker/date-range-picker.component.ts
+++ b/src/app/components/date-range-picker/date-range-picker.component.ts
@@ -43,11 +43,11 @@ export class DateRangePickerComponent implements ControlValueAccessor, OnDestroy
 	readonly startDateErrorsHandler = this.errorHandlerService.getDatepickerErrorsHandler('Start Date');
 	readonly endDateErrorsHandler = this.errorHandlerService.getDatepickerErrorsHandler('End Date');
 
-	// onChange callback that will be overriden using `registerOnChange`
-	onChange: (dateRange: DateRange) => void = () => {
+	// onChange callback that will be overridden using `registerOnChange`
+	onChange: (dateRange?: DateRange | null) => void = () => {
 		/** empty */
 	};
-	// onTouched callback that will be overriden using `registerOnTouched`
+	// onTouched callback that will be overridden using `registerOnTouched`
 	onTouched = () => {
 		/** empty */
 	};
@@ -111,7 +111,21 @@ export class DateRangePickerComponent implements ControlValueAccessor, OnDestroy
 	/**
 	 * Set Component's ControlValueAccessor value
 	 */
-	writeValue([start, end]: DateRange): void {
+	writeValue(dateRange?: DateRange | null): void {
+		// Clear start and end FormControl's value when trying to set
+		// date range to something that isn't iterable to avoid spreading
+		// values to `start` and `end` FormControls
+		if (!Array.isArray(dateRange)) {
+			this.dateRangeFormGroup.setValue({
+				start: null,
+				end: null,
+			});
+			return;
+		}
+
+		const [start, end] = dateRange;
+
+		// Validation on start and end themselves are handled by their FormControls.
 		this.dateRangeFormGroup.setValue({ start, end });
 	}
 

--- a/src/app/components/date-range-picker/date-range-picker.component.ts
+++ b/src/app/components/date-range-picker/date-range-picker.component.ts
@@ -1,0 +1,144 @@
+import { ChangeDetectionStrategy, Component, forwardRef, inject, OnDestroy } from '@angular/core';
+import {
+	ControlValueAccessor,
+	FormControl,
+	FormGroup,
+	NG_VALIDATORS,
+	NG_VALUE_ACCESSOR,
+	ValidationErrors,
+	Validators,
+} from '@angular/forms';
+import { Subject, takeUntil, tap } from 'rxjs';
+import { ErrorHandlerService } from '../../services';
+
+export type DateRange = [Date, Date];
+
+@Component({
+	selector: 'app-date-range-picker',
+	templateUrl: './date-range-picker.component.html',
+	styleUrls: ['./date-range-picker.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: NG_VALIDATORS,
+			useExisting: forwardRef(() => DateRangePickerComponent),
+			multi: true,
+		},
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => DateRangePickerComponent),
+			multi: true,
+		},
+	],
+})
+export class DateRangePickerComponent implements ControlValueAccessor, OnDestroy {
+	private readonly errorHandlerService = inject(ErrorHandlerService);
+
+	// inner FormGroup used to manage ControlValueAccessor value
+	readonly dateRangeFormGroup = this.getDateRangeFormGroup();
+
+	readonly minDate = new Date(2015, 0, 1);
+	readonly maxDate = new Date();
+
+	// Start and End ErrorHandlers used to populate `mat-error`
+	readonly startDateErrorsHandler = this.errorHandlerService.getDatepickerErrorsHandler('Start Date');
+	readonly endDateErrorsHandler = this.errorHandlerService.getDatepickerErrorsHandler('End Date');
+
+	// onChange callback that will be overriden using `registerOnChange`
+	onChange: (dateRange: DateRange) => void = () => {
+		/** empty */
+	};
+	// onTouched callback that will be overriden using `registerOnTouched`
+	onTouched = () => {
+		/** empty */
+	};
+
+	/**
+	 * Bubbles up MatDateRangePicker errors to this
+	 * Component's ControlValueAccessor validators
+	 */
+	matDateRangePickerValidators = (): ValidationErrors | null => {
+		const nestedErrors =
+			this.dateRangeFormGroup.errors ??
+			this.dateRangeFormGroup.controls.start.errors ??
+			this.dateRangeFormGroup.controls.end.errors;
+
+		if (nestedErrors) {
+			return nestedErrors;
+		}
+
+		return null;
+	};
+
+	private readonly destroyer$ = new Subject<void>();
+
+	constructor() {
+		this.dateRangeFormGroup.valueChanges
+			.pipe(
+				tap(({ start, end }) => {
+					if (!this.dateRangeFormGroup.valid) {
+						return;
+					}
+
+					if (!start || !end) {
+						return;
+					}
+
+					this.onChange([start, end]);
+				}),
+				takeUntil(this.destroyer$)
+			)
+			.subscribe();
+	}
+
+	/**
+	 * Creates FormGroup that is responsible for setting
+	 * Component's ControlValueAccessor value
+	 */
+	getDateRangeFormGroup(): FormGroup<{
+		start: FormControl<Date | null>;
+		end: FormControl<Date | null>;
+	}> {
+		return new FormGroup({
+			start: new FormControl<Date | null>(null, {
+				validators: Validators.required,
+			}),
+			end: new FormControl<Date | null>(null, {
+				validators: Validators.required,
+			}),
+		});
+	}
+
+	/**
+	 * Set Component's ControlValueAccessor value
+	 */
+	writeValue([start, end]: DateRange): void {
+		this.dateRangeFormGroup.setValue({ start, end });
+	}
+
+	/**
+	 * Register Component's ControlValueAccessor onChange callback
+	 */
+	registerOnChange(fn: DateRangePickerComponent['onChange']): void {
+		this.onChange = fn;
+	}
+
+	/**
+	 * Register Component's ControlValueAccessor onTouched callback
+	 */
+	registerOnTouched(fn: DateRangePickerComponent['onTouched']): void {
+		this.onTouched = fn;
+	}
+
+	/**
+	 * Provides validators
+	 */
+	validate(): ValidationErrors | null {
+		return this.matDateRangePickerValidators();
+	}
+
+	ngOnDestroy(): void {
+		this.destroyer$.next();
+		this.destroyer$.complete();
+	}
+}

--- a/src/app/components/date-range-picker/date-range-picker.component.ts
+++ b/src/app/components/date-range-picker/date-range-picker.component.ts
@@ -9,9 +9,8 @@ import {
 	Validators,
 } from '@angular/forms';
 import { Subject, takeUntil, tap } from 'rxjs';
+import { DateRange } from '../../models';
 import { ErrorHandlerService } from '../../services';
-
-export type DateRange = [Date, Date];
 
 @Component({
 	selector: 'app-date-range-picker',

--- a/src/app/models/date-range.model.ts
+++ b/src/app/models/date-range.model.ts
@@ -1,0 +1,1 @@
+export type DateRange = [Date, Date];

--- a/src/app/models/index.ts
+++ b/src/app/models/index.ts
@@ -1,1 +1,2 @@
 export * from './chart-data.model';
+export * from './date-range.model';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,3 +30,8 @@ body {
 	flex-wrap: wrap;
 	gap: $padding * 0.25;
 }
+
+mat-form-field {
+	max-width: 320px;
+	width: 100%;
+}


### PR DESCRIPTION
### Description
Migrated DateRangPicker logic to a Component. AppComponent now tracks a `FormControl<[Date, Date]>` instead of `FormGroup<{ FormControl<Date>, FormControl<Date>}>` for date range state

Jira: https://bitovi.atlassian.net/browse/AOS2-14

- [x] implement ControlValueAccessor
- [x] implement Validator
- [x] AppComponent should pass a FormControl<[Date | null, Date | null]>
- [x] Comment code
- [x] migrate app styles to global styles as needed