### PR TITLE
feat(autocomplete): removed add button

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,21 +30,11 @@
 		<form onsubmit="return false">
 			<!-- auto complete -->
 			<app-autocomplete
+				(selectedPackage)="onPackageNameSubmit()"
 				[autocomplateOptions]="autocompleteOptions$ | async"
 				[formControl]="addPackage"
 				[loadedEntities$]="packageNames.observable$"
 			></app-autocomplete>
-
-			<!-- add button -->
-			<button
-				mat-raised-button
-				type="submit"
-				color="primary"
-				[disabled]="!addPackage.value || addPackage.invalid"
-				(click)="onPackageNameSubmit()"
-			>
-				Add
-			</button>
 		</form>
 
 		<!-- list of selected libraries -->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,7 +30,7 @@
 		<form onsubmit="return false">
 			<!-- auto complete -->
 			<app-autocomplete
-				(selectedPackage)="onPackageNameSubmit()"
+				(selectedOption)="onPackageNameSubmit()"
 				[autocomplateOptions]="autocompleteOptions$ | async"
 				[formControl]="addPackage"
 				[loadedEntities$]="packageNames.observable$"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,8 +30,9 @@
 		<form onsubmit="return false">
 			<!-- auto complete -->
 			<app-autocomplete
+				*ngIf="autocompleteOptions$ | async as autocompleteOptions"
 				(selectedOption)="onPackageNameSubmit()"
-				[autocomplateOptions]="autocompleteOptions$ | async"
+				[autocomplateOptions]="autocompleteOptions"
 				[formControl]="addPackage"
 				[loadedEntities$]="packageNames.observable$"
 			></app-autocomplete>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -29,11 +29,6 @@ form {
 	flex-wrap: wrap;
 	align-items: center;
 	gap: $padding * 0.25;
-
-	button {
-		// button doesn't naturally align with input because of its mat-hint/mat-error
-		margin-bottom: 3px;
-	}
 }
 
 .clear-cache-button:not(:focus):not(:hover) {

--- a/src/app/components/autocomplete/autocomplete.component.html
+++ b/src/app/components/autocomplete/autocomplete.component.html
@@ -1,12 +1,12 @@
 <mat-form-field appearance="outline">
 	<mat-label>npm package name</mat-label>
-	<input matInput [formControl]="addPackage" [matAutocomplete]="auto" />
+	<input matInput [formControl]="addOption" [matAutocomplete]="auto" (keyup.enter)="onChooseFirstOption()" />
 	<mat-hint>Ex: 'canjs'</mat-hint>
-	<mat-error appErrorHandler [errors$]="addPackage.errors| toObservable" [handleErrors]="packageErrorsHandler">
+	<mat-error appErrorHandler [errors$]="addOption.errors| toObservable" [handleErrors]="packageErrorsHandler">
 	</mat-error>
 
 	<!-- display options -->
-	<mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOptionSelected($event)">
+	<mat-autocomplete #auto="matAutocomplete">
 		<mat-option *ngFor="let option of autocomplateOptions" [value]="option"> {{ option }} </mat-option>
 	</mat-autocomplete>
 </mat-form-field>

--- a/src/app/components/autocomplete/autocomplete.component.html
+++ b/src/app/components/autocomplete/autocomplete.component.html
@@ -6,7 +6,7 @@
 	</mat-error>
 
 	<!-- display options -->
-	<mat-autocomplete #auto="matAutocomplete">
+	<mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOptionSelected($event)">
 		<mat-option
 			*ngFor="let option of autocomplateOptions"
 			[value]="option"

--- a/src/app/components/autocomplete/autocomplete.component.html
+++ b/src/app/components/autocomplete/autocomplete.component.html
@@ -7,12 +7,6 @@
 
 	<!-- display options -->
 	<mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOptionSelected($event)">
-		<mat-option
-			*ngFor="let option of autocomplateOptions"
-			[value]="option"
-			(onSelectionChange)="onSelectionChange(option)"
-		>
-			{{ option }}
-		</mat-option>
+		<mat-option *ngFor="let option of autocomplateOptions" [value]="option"> {{ option }} </mat-option>
 	</mat-autocomplete>
 </mat-form-field>

--- a/src/app/components/autocomplete/autocomplete.component.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.component.spec.ts
@@ -136,7 +136,7 @@ describe('AutocompleteComponent', () => {
 			const input = 'Angular';
 			component.autocomplateOptions = [input, 'Test2'];
 
-			component.onChooseFirstOption();
+			component.onEnterKey();
 
 			expect(emitSpy).toHaveBeenCalled();
 			expect(onChangeSpy).toHaveBeenCalledWith(input);
@@ -148,7 +148,7 @@ describe('AutocompleteComponent', () => {
 
 			component.autocomplateOptions = [];
 
-			component.onChooseFirstOption();
+			component.onEnterKey();
 
 			expect(emitSpy).toHaveBeenCalled();
 			expect(onChangeSpy).not.toHaveBeenCalled();

--- a/src/app/components/autocomplete/autocomplete.component.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.component.spec.ts
@@ -1,7 +1,8 @@
 import { Component, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
-import { MatAutocomplete } from '@angular/material/autocomplete';
+import { NG_VALIDATORS, NG_VALUE_ACCESSOR, ReactiveFormsModule, ValidationErrors } from '@angular/forms';
+import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { of } from 'rxjs';
 
 import { ErrorHandlerDirective } from './../../directives';
 import { ToObservablePipe } from './../../pipes';
@@ -48,12 +49,18 @@ describe('AutocompleteComponent', () => {
 	let component: AutocompleteComponent;
 	let fixture: ComponentFixture<AutocompleteComponent>;
 
-	const errorHandlerServiceMock = {
-		noDuplicatesValidator: jest.fn(),
-		getInputErrorsHandler: jest.fn(),
-	};
+	let errorHandlerServiceMock: ErrorHandlerService;
+
+	const noDuplicatesValidatorFn = () => of({} as ValidationErrors);
+	const componentFn = () => AutocompleteComponent;
 
 	beforeEach(async () => {
+		errorHandlerServiceMock = {
+			getDatepickerErrorsHandler: jest.fn(),
+			noDuplicatesValidator: () => noDuplicatesValidatorFn,
+			getInputErrorsHandler: jest.fn(),
+		};
+
 		await TestBed.configureTestingModule({
 			declarations: [
 				AutocompleteComponent,
@@ -68,15 +75,134 @@ describe('AutocompleteComponent', () => {
 				MatAutocomplete, // Required for #auto="matAutocomplete" directive
 			],
 			imports: [ReactiveFormsModule],
-			providers: [{ provide: ErrorHandlerService, useValue: errorHandlerServiceMock }],
+			providers: [
+				{ provide: ErrorHandlerService, useValue: errorHandlerServiceMock },
+				{ provide: NG_VALUE_ACCESSOR, useExisting: componentFn, multi: true },
+				{ provide: NG_VALIDATORS, useExisting: componentFn, multi: true },
+			],
 		}).compileComponents();
 
 		fixture = TestBed.createComponent(AutocompleteComponent);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
+
+		// trigger control value accessor functions
+		component.registerOnChange(jest.fn());
+		component.registerOnTouched(jest.fn());
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
 	});
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	describe('Test: providers', () => {
+		it('should return AutocompleteComponent', () => {
+			expect(componentFn()).toBe(AutocompleteComponent);
+		});
+	});
+
+	describe('Test: ngOnInit()', () => {
+		it('should create a form control for addPackage', () => {
+			expect(component.addPackage).toBeDefined();
+			expect(component.addPackage.value).toEqual('');
+
+			expect(component.addPackage.asyncValidator).toBeTruthy();
+			expect(component.addPackage.hasAsyncValidator(noDuplicatesValidatorFn)).toBe(true);
+		});
+
+		it('should subscribe on form control value change', () => {
+			expect(component.onChange).not.toHaveBeenCalled();
+			component.addPackage.patchValue('test');
+			expect(component.onChange).toHaveBeenCalledWith('test');
+		});
+	});
+
+	describe('Test: ngOnDestroy()', () => {
+		it('should complete unsubscribe$ subject', () => {
+			expect(component['unsubscribe$']).toBeDefined();
+
+			const completeSpy = jest.spyOn(component['unsubscribe$'], 'complete');
+			const nextSpy = jest.spyOn(component['unsubscribe$'], 'next');
+			component.ngOnDestroy();
+
+			expect(nextSpy).toHaveBeenCalled();
+			expect(completeSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('Test: onOptionSelected()', () => {
+		it('should notify parent about the selected package name', () => {
+			const mockPackageName = 'Angular';
+
+			const mockInput: MatAutocompleteSelectedEvent = {
+				option: {
+					value: mockPackageName,
+				},
+			} as MatAutocompleteSelectedEvent;
+
+			const emitSpy = jest.spyOn(component.selectedPackage, 'emit');
+			const onChangeSpy = jest.spyOn(component, 'onChange');
+
+			component.onOptionSelected(mockInput);
+
+			expect(onChangeSpy).toHaveBeenCalledWith(mockPackageName);
+			expect(emitSpy).toHaveBeenCalledWith(mockPackageName);
+		});
+	});
+
+	describe('Test: writeValue()', () => {
+		it('should set value for addPackage formControl', () => {
+			const mockInput = 'Angular';
+
+			expect(component.addPackage.value).toEqual('');
+			component.writeValue(mockInput);
+			expect(component.addPackage.value).toEqual(mockInput);
+			component.writeValue(undefined);
+			expect(component.addPackage.value).toEqual('');
+		});
+	});
+
+	describe('Test: registerOnChange()', () => {
+		it('should add function to onChange', () => {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const mockFn = (value: string) => {
+				/**EMPTY */
+			};
+			component.registerOnChange(mockFn);
+			expect(component.onChange).toEqual(mockFn);
+		});
+	});
+
+	describe('Test: registerOnTouched()', () => {
+		it('should add function to onTouched', () => {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const mockFn = (value: void) => {
+				/**EMPTY */
+			};
+			component.registerOnTouched(mockFn);
+			expect(component.onTouched).toEqual(mockFn);
+		});
+	});
+
+	describe('Test: validate()', () => {
+		it('should return error if addPackage is invalid', () => {
+			const mockErrors = () => ({} as ValidationErrors);
+
+			component.addPackage.setErrors(mockErrors);
+
+			expect(component.addPackage.errors).toBe(mockErrors);
+			expect(component.validate()).toBe(mockErrors);
+		});
+
+		it('should return null if addPackage is valid', () => {
+			component.addPackage.setErrors(null);
+
+			expect(component.addPackage.errors).toBe(null);
+			expect(component.validate()).toBe(null);
+		});
 	});
 });

--- a/src/app/components/autocomplete/autocomplete.component.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, ValidationErrors } from '@angular/forms';
-import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MatAutocomplete } from '@angular/material/autocomplete';
 import { of } from 'rxjs';
 
 import { ErrorHandlerDirective } from './../../directives';
@@ -101,16 +101,16 @@ describe('AutocompleteComponent', () => {
 
 	describe('ngOnInit()', () => {
 		it('should create a form control for addPackage', () => {
-			expect(component.addPackage).toBeDefined();
-			expect(component.addPackage.value).toEqual('');
+			expect(component.addOption).toBeDefined();
+			expect(component.addOption.value).toEqual('');
 
-			expect(component.addPackage.asyncValidator).toBeTruthy();
-			expect(component.addPackage.hasAsyncValidator(noDuplicatesValidatorFn)).toBe(true);
+			expect(component.addOption.asyncValidator).toBeTruthy();
+			expect(component.addOption.hasAsyncValidator(noDuplicatesValidatorFn)).toBe(true);
 		});
 
 		it('should subscribe on form control value change', () => {
 			expect(component.onChange).not.toHaveBeenCalled();
-			component.addPackage.patchValue('test');
+			component.addOption.patchValue('test');
 			expect(component.onChange).toHaveBeenCalledWith('test');
 		});
 	});
@@ -128,23 +128,30 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('onOptionSelected()', () => {
-		it('should notify parent about the selected package name', () => {
-			const mockPackageName = 'Angular';
-
-			const mockInput: MatAutocompleteSelectedEvent = {
-				option: {
-					value: mockPackageName,
-				},
-			} as MatAutocompleteSelectedEvent;
-
-			const emitSpy = jest.spyOn(component.selectedPackage, 'emit');
+	describe('onChooseFirstOption()', () => {
+		it('should select the first element in matAutocomplete.options', () => {
+			const emitSpy = jest.spyOn(component.selectedOption, 'emit');
 			const onChangeSpy = jest.spyOn(component, 'onChange');
 
-			component.onOptionSelected(mockInput);
+			const input = 'Angular';
+			component.autocomplateOptions = [input, 'Test2'];
 
-			expect(onChangeSpy).toHaveBeenCalledWith(mockPackageName);
-			expect(emitSpy).toHaveBeenCalledWith(mockPackageName);
+			component.onChooseFirstOption();
+
+			expect(emitSpy).toHaveBeenCalled();
+			expect(onChangeSpy).toHaveBeenCalledWith(input);
+		});
+
+		it('should not notify parent by onChange if there is not value in autocomplateOptions', () => {
+			const emitSpy = jest.spyOn(component.selectedOption, 'emit');
+			const onChangeSpy = jest.spyOn(component, 'onChange');
+
+			component.autocomplateOptions = [];
+
+			component.onChooseFirstOption();
+
+			expect(emitSpy).toHaveBeenCalled();
+			expect(onChangeSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -152,11 +159,11 @@ describe('AutocompleteComponent', () => {
 		it('should set value for addPackage formControl', () => {
 			const mockInput = 'Angular';
 
-			expect(component.addPackage.value).toEqual('');
+			expect(component.addOption.value).toEqual('');
 			component.writeValue(mockInput);
-			expect(component.addPackage.value).toEqual(mockInput);
+			expect(component.addOption.value).toEqual(mockInput);
 			component.writeValue(undefined);
-			expect(component.addPackage.value).toEqual('');
+			expect(component.addOption.value).toEqual('');
 		});
 	});
 
@@ -186,16 +193,16 @@ describe('AutocompleteComponent', () => {
 		it('should return error if addPackage is invalid', () => {
 			const mockErrors = () => ({} as ValidationErrors);
 
-			component.addPackage.setErrors(mockErrors);
+			component.addOption.setErrors(mockErrors);
 
-			expect(component.addPackage.errors).toBe(mockErrors);
+			expect(component.addOption.errors).toBe(mockErrors);
 			expect(component.validate()).toBe(mockErrors);
 		});
 
 		it('should return null if addPackage is valid', () => {
-			component.addPackage.setErrors(null);
+			component.addOption.setErrors(null);
 
-			expect(component.addPackage.errors).toBe(null);
+			expect(component.addOption.errors).toBe(null);
 			expect(component.validate()).toBe(null);
 		});
 	});

--- a/src/app/components/autocomplete/autocomplete.component.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.component.spec.ts
@@ -1,14 +1,13 @@
 import { Component, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NG_VALIDATORS, NG_VALUE_ACCESSOR, ReactiveFormsModule, ValidationErrors } from '@angular/forms';
+import { ReactiveFormsModule, ValidationErrors } from '@angular/forms';
 import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { of } from 'rxjs';
 
 import { ErrorHandlerDirective } from './../../directives';
 import { ToObservablePipe } from './../../pipes';
 import { ErrorHandlerService } from './../../services/error-handler';
-
-import { AutocompleteComponent } from './autocomplete.component';
+import { AutocompleteComponent, autocompleteComponentFn } from './autocomplete.component';
 
 @Component({
 	selector: 'mat-label',
@@ -52,7 +51,6 @@ describe('AutocompleteComponent', () => {
 	let errorHandlerServiceMock: ErrorHandlerService;
 
 	const noDuplicatesValidatorFn = () => of({} as ValidationErrors);
-	const componentFn = () => AutocompleteComponent;
 
 	beforeEach(async () => {
 		errorHandlerServiceMock = {
@@ -75,11 +73,7 @@ describe('AutocompleteComponent', () => {
 				MatAutocomplete, // Required for #auto="matAutocomplete" directive
 			],
 			imports: [ReactiveFormsModule],
-			providers: [
-				{ provide: ErrorHandlerService, useValue: errorHandlerServiceMock },
-				{ provide: NG_VALUE_ACCESSOR, useExisting: componentFn, multi: true },
-				{ provide: NG_VALIDATORS, useExisting: componentFn, multi: true },
-			],
+			providers: [{ provide: ErrorHandlerService, useValue: errorHandlerServiceMock }],
 		}).compileComponents();
 
 		fixture = TestBed.createComponent(AutocompleteComponent);
@@ -101,7 +95,7 @@ describe('AutocompleteComponent', () => {
 
 	describe('Test: providers', () => {
 		it('should return AutocompleteComponent', () => {
-			expect(componentFn()).toBe(AutocompleteComponent);
+			expect(autocompleteComponentFn()).toBe(AutocompleteComponent);
 		});
 	});
 

--- a/src/app/components/autocomplete/autocomplete.component.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.component.spec.ts
@@ -128,7 +128,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('onChooseFirstOption()', () => {
+	describe('onEnterKey()', () => {
 		it('should select the first element in matAutocomplete.options', () => {
 			const emitSpy = jest.spyOn(component.selectedOption, 'emit');
 			const onChangeSpy = jest.spyOn(component, 'onChange');

--- a/src/app/components/autocomplete/autocomplete.component.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.component.spec.ts
@@ -93,13 +93,13 @@ describe('AutocompleteComponent', () => {
 		expect(component).toBeTruthy();
 	});
 
-	describe('Test: providers', () => {
+	describe('autocompleteComponentFn()', () => {
 		it('should return AutocompleteComponent', () => {
 			expect(autocompleteComponentFn()).toBe(AutocompleteComponent);
 		});
 	});
 
-	describe('Test: ngOnInit()', () => {
+	describe('ngOnInit()', () => {
 		it('should create a form control for addPackage', () => {
 			expect(component.addPackage).toBeDefined();
 			expect(component.addPackage.value).toEqual('');
@@ -115,7 +115,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('Test: ngOnDestroy()', () => {
+	describe('ngOnDestroy()', () => {
 		it('should complete unsubscribe$ subject', () => {
 			expect(component['unsubscribe$']).toBeDefined();
 
@@ -128,7 +128,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('Test: onOptionSelected()', () => {
+	describe('onOptionSelected()', () => {
 		it('should notify parent about the selected package name', () => {
 			const mockPackageName = 'Angular';
 
@@ -148,7 +148,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('Test: writeValue()', () => {
+	describe('writeValue()', () => {
 		it('should set value for addPackage formControl', () => {
 			const mockInput = 'Angular';
 
@@ -160,7 +160,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('Test: registerOnChange()', () => {
+	describe('registerOnChange()', () => {
 		it('should add function to onChange', () => {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const mockFn = (value: string) => {
@@ -171,7 +171,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('Test: registerOnTouched()', () => {
+	describe('registerOnTouched()', () => {
 		it('should add function to onTouched', () => {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const mockFn = (value: void) => {
@@ -182,7 +182,7 @@ describe('AutocompleteComponent', () => {
 		});
 	});
 
-	describe('Test: validate()', () => {
+	describe('validate()', () => {
 		it('should return error if addPackage is invalid', () => {
 			const mockErrors = () => ({} as ValidationErrors);
 

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -21,6 +21,8 @@ import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Observable, Subject, takeUntil } from 'rxjs';
 import { ErrorHandlerService } from '../../services';
 
+export const autocompleteComponentFn = () => AutocompleteComponent;
+
 @Component({
 	selector: 'app-autocomplete',
 	templateUrl: './autocomplete.component.html',
@@ -29,12 +31,12 @@ import { ErrorHandlerService } from '../../services';
 	providers: [
 		{
 			provide: NG_VALUE_ACCESSOR,
-			useExisting: forwardRef(() => AutocompleteComponent),
+			useExisting: forwardRef(autocompleteComponentFn),
 			multi: true,
 		},
 		{
 			provide: NG_VALIDATORS,
-			useExisting: forwardRef(() => AutocompleteComponent),
+			useExisting: forwardRef(autocompleteComponentFn),
 			multi: true,
 		},
 	],

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -49,7 +49,7 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	/*
     package names that should be displayed as options in the select
   */
-	@Input() autocomplateOptions: string[] | null = [];
+	@Input() autocomplateOptions: string[] = [];
 
 	/*
     entity objects (package names) that are already loaded, to prevent duplicated loading
@@ -90,7 +90,7 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	 * On enter click, select first element from the autocomplete dropdown if exists
 	 */
 	onEnterKey() {
-		const value = this.autocomplateOptions?.[0];
+		const value = this.autocomplateOptions.at(0);
 
 		if (value) {
 			// save package name to parent's form control

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -87,6 +87,11 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 
 	onOptionSelected(event: MatAutocompleteSelectedEvent): void {
 		const packageName = event.option.value;
+
+		// save package name to parent's form control
+		this.onChange(packageName);
+
+		// emit to parent that a package has been chosen
 		this.selectedPackage.emit(packageName);
 	}
 
@@ -98,10 +103,6 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	}
 	registerOnTouched(fn: (value: void) => void): void {
 		this.onTouched = fn;
-	}
-
-	onSelectionChange(value: string): void {
-		this.onChange(value);
 	}
 
 	validate(): ValidationErrors | null {

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -89,7 +89,7 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	/**
 	 * On enter click, select first element from the autocomplete dropdown if exists
 	 */
-	onChooseFirstOption() {
+	onEnterKey() {
 		const value = this.autocomplateOptions?.[0];
 
 		if (value) {

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -17,7 +17,6 @@ import {
 	ValidationErrors,
 	Validators,
 } from '@angular/forms';
-import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Observable, Subject, takeUntil } from 'rxjs';
 import { ErrorHandlerService } from '../../services';
 
@@ -43,9 +42,9 @@ export const autocompleteComponentFn = () => AutocompleteComponent;
 })
 export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAccessor, Validators {
 	/**
-	 * Emites selected package name from the autocomplete by the user
+	 * Emites selected option from the autocomplete by the user
 	 */
-	@Output() selectedPackage: EventEmitter<string> = new EventEmitter<string>();
+	@Output() selectedOption: EventEmitter<void> = new EventEmitter<void>();
 
 	/*
     package names that should be displayed as options in the select
@@ -61,7 +60,7 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	private readonly unsubscribe$ = new Subject<void>();
 
 	/* Form control to allow user search packages  */
-	addPackage!: FormControl<string>;
+	addOption!: FormControl<string>;
 
 	/* errors that may occur when searching for a package name */
 	readonly packageErrorsHandler = this.errorHandlerService.getInputErrorsHandler('package name');
@@ -75,11 +74,11 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	};
 
 	ngOnInit(): void {
-		this.addPackage = new FormControl('', {
+		this.addOption = new FormControl('', {
 			nonNullable: true,
 			asyncValidators: this.errorHandlerService.noDuplicatesValidator(this.loadedEntities$),
 		});
-		this.addPackage.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe((value) => this.onChange(value));
+		this.addOption.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe((value) => this.onChange(value));
 	}
 
 	ngOnDestroy(): void {
@@ -87,18 +86,23 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 		this.unsubscribe$.complete();
 	}
 
-	onOptionSelected(event: MatAutocompleteSelectedEvent): void {
-		const packageName = event.option.value;
+	/**
+	 * On enter click, select first element from the autocomplete dropdown if exists
+	 */
+	onChooseFirstOption() {
+		const value = this.autocomplateOptions?.[0];
 
-		// save package name to parent's form control
-		this.onChange(packageName);
+		if (value) {
+			// save package name to parent's form control
+			this.onChange(value);
+		}
 
 		// emit to parent that a package has been chosen
-		this.selectedPackage.emit(packageName);
+		this.selectedOption.emit();
 	}
 
 	writeValue(value?: string): void {
-		this.addPackage.setValue(value ?? '');
+		this.addOption.setValue(value ?? '');
 	}
 
 	registerOnChange(fn: (value: string) => void): void {
@@ -110,8 +114,8 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	}
 
 	validate(): ValidationErrors | null {
-		if (this.addPackage.errors) {
-			return this.addPackage.errors;
+		if (this.addOption.errors) {
+			return this.addOption.errors;
 		}
 		return null;
 	}

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectionStrategy, Component, forwardRef, inject, Input, OnDestroy, OnInit } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	EventEmitter,
+	forwardRef,
+	inject,
+	Input,
+	OnDestroy,
+	OnInit,
+	Output,
+} from '@angular/core';
 import {
 	ControlValueAccessor,
 	FormControl,
@@ -7,6 +17,7 @@ import {
 	ValidationErrors,
 	Validators,
 } from '@angular/forms';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Observable, Subject, takeUntil } from 'rxjs';
 import { ErrorHandlerService } from '../../services';
 
@@ -29,6 +40,11 @@ import { ErrorHandlerService } from '../../services';
 	],
 })
 export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAccessor, Validators {
+	/**
+	 * Emites selected package name from the autocomplete by the user
+	 */
+	@Output() selectedPackage: EventEmitter<string> = new EventEmitter<string>();
+
 	/*
     package names that should be displayed as options in the select
   */
@@ -67,6 +83,11 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	ngOnDestroy(): void {
 		this.unsubscribe$.next();
 		this.unsubscribe$.complete();
+	}
+
+	onOptionSelected(event: MatAutocompleteSelectedEvent): void {
+		const packageName = event.option.value;
+		this.selectedPackage.emit(packageName);
 	}
 
 	writeValue(value?: string): void {

--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -98,9 +98,11 @@ export class AutocompleteComponent implements OnInit, OnDestroy, ControlValueAcc
 	writeValue(value?: string): void {
 		this.addPackage.setValue(value ?? '');
 	}
+
 	registerOnChange(fn: (value: string) => void): void {
 		this.onChange = fn;
 	}
+
 	registerOnTouched(fn: (value: void) => void): void {
 		this.onTouched = fn;
 	}


### PR DESCRIPTION
Tickets: https://bitovi.atlassian.net/browse/AOS2-28, https://bitovi.atlassian.net/browse/AOS2-25

- [x] - Remove add button from dom
- [x] - Clean up unneeded dom complexity for styling
- [x] - [Angular Material](https://material.angular.io/components/autocomplete/api#MatAutocomplete) optionSelected
- [x] - event emitter should be used -> FormGroup from parent can listen to to submit
- [x] - Fully unit test AutocompleteComponent
- [x] - Add accessibility to selecting a package by enter click - the package will be selected based on the input value